### PR TITLE
Templated rviz plugins to extend functionality to OcTreeStamped

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+*.project
+*.cproject
+*.*~

--- a/include/octomap_rviz_plugins/occupancy_grid_display.h
+++ b/include/octomap_rviz_plugins/occupancy_grid_display.h
@@ -127,7 +127,7 @@ protected:
   double color_factor_;
 };
 
-template <typename OcTreeType, typename OcNodeType>
+template <typename OcTreeType>
 class TemplatedOccupancyGridDisplay: public OccupancyGridDisplay {
 protected:
   void incomingMessageCallback(const octomap_msgs::OctomapConstPtr& msg);

--- a/include/octomap_rviz_plugins/occupancy_grid_display.h
+++ b/include/octomap_rviz_plugins/occupancy_grid_display.h
@@ -43,6 +43,8 @@
 
 #include <octomap_msgs/Octomap.h>
 
+#include <octomap/OcTreeStamped.h>
+
 #include <rviz/display.h>
 #include "rviz/ogre_helpers/point_cloud.h"
 
@@ -52,7 +54,7 @@ namespace rviz {
 class RosTopicProperty;
 class IntProperty;
 class EnumProperty;
- class FloatProperty;
+class FloatProperty;
 }
 
 namespace octomap_rviz_plugin
@@ -88,7 +90,7 @@ protected:
   void subscribe();
   void unsubscribe();
 
-  void incomingMessageCallback(const octomap_msgs::OctomapConstPtr& msg);
+  virtual void incomingMessageCallback(const octomap_msgs::OctomapConstPtr& msg) = 0;
 
   void setColor( double z_pos, double min_z, double max_z, double color_factor, rviz::PointCloud::Point& point);
 
@@ -123,6 +125,12 @@ protected:
   u_int32_t queue_size_;
   uint32_t messages_received_;
   double color_factor_;
+};
+
+template <typename OcTreeType, typename OcNodeType>
+class TemplatedOccupancyGridDisplay: public OccupancyGridDisplay {
+protected:
+  void incomingMessageCallback(const octomap_msgs::OctomapConstPtr& msg);
 };
 
 } // namespace octomap_rviz_plugin

--- a/include/octomap_rviz_plugins/occupancy_map_display.h
+++ b/include/octomap_rviz_plugins/occupancy_map_display.h
@@ -76,7 +76,7 @@ protected:
   rviz::IntProperty* tree_depth_property_;
 };
 
-template <typename OcTreeType, typename OcNodeType>
+template <typename OcTreeType>
 class TemplatedOccupancyMapDisplay: public OccupancyMapDisplay {
 protected:
     void handleOctomapBinaryMessage(const octomap_msgs::OctomapConstPtr& msg);

--- a/include/octomap_rviz_plugins/occupancy_map_display.h
+++ b/include/octomap_rviz_plugins/occupancy_map_display.h
@@ -43,6 +43,8 @@
 
 #include <octomap_msgs/Octomap.h>
 
+#include <octomap/OcTreeStamped.h>
+
 #include <message_filters/subscriber.h>
 
 #endif
@@ -66,12 +68,18 @@ protected:
   virtual void subscribe();
   virtual void unsubscribe();
 
-  void handleOctomapBinaryMessage(const octomap_msgs::OctomapConstPtr& msg);
+  virtual void handleOctomapBinaryMessage(const octomap_msgs::OctomapConstPtr& msg) = 0;
 
   boost::shared_ptr<message_filters::Subscriber<octomap_msgs::Octomap> > sub_;
 
   unsigned int octree_depth_;
   rviz::IntProperty* tree_depth_property_;
+};
+
+template <typename OcTreeType, typename OcNodeType>
+class TemplatedOccupancyMapDisplay: public OccupancyMapDisplay {
+protected:
+    void handleOctomapBinaryMessage(const octomap_msgs::OctomapConstPtr& msg);
 };
 
 } // namespace rviz

--- a/plugin_description.xml
+++ b/plugin_description.xml
@@ -1,14 +1,29 @@
 
 <library path="lib/liboctomap_rviz_plugins">
   <class name="octomap_rviz_plugin/OccupancyGrid"
-         type="octomap_rviz_plugin::OccupancyGridDisplay"
+         type="OcTreeGridDisplay"
          base_class_type="rviz::Display">
     <description>
       Displays 3D occupancy grids generated from compressed octomap messages.
     </description>
   </class>
+  <class name="octomap_rviz_plugin/OccupancyGridStamped"
+         type="OcTreeStampedGridDisplay"
+         base_class_type="rviz::Display">
+    <description>
+      Displays 3D occupancy grids generated from compressed octomap messages.
+    </description>
+  </class>
+  
   <class name="octomap_rviz_plugin/OccupancyMap"
-	     type="octomap_rviz_plugin::OccupancyMapDisplay"
+	     type="OcTreeMapDisplay"
+	     base_class_type="rviz::Display">
+    <description>
+      Displays projected 2D occupancy maps generated from compressed octomap messages.
+    </description>
+  </class>
+  <class name="octomap_rviz_plugin/OccupancyMapStamped"
+	     type="OcTreeStampedMapDisplay"
 	     base_class_type="rviz::Display">
     <description>
       Displays projected 2D occupancy maps generated from compressed octomap messages.

--- a/src/occupancy_grid_display.cpp
+++ b/src/occupancy_grid_display.cpp
@@ -359,8 +359,8 @@ void OccupancyGridDisplay::updateTopic()
 }
 
 
-template <typename OcTreeType, typename OcNodeType>
-void TemplatedOccupancyGridDisplay<OcTreeType, OcNodeType>::incomingMessageCallback(const octomap_msgs::OctomapConstPtr& msg)
+template <typename OcTreeType>
+void TemplatedOccupancyGridDisplay<OcTreeType>::incomingMessageCallback(const octomap_msgs::OctomapConstPtr& msg)
 {
   ++messages_received_;
   setStatus(StatusProperty::Ok, "Messages", QString::number(messages_received_) + " octomap messages received");
@@ -451,7 +451,7 @@ void TemplatedOccupancyGridDisplay<OcTreeType, OcNodeType>::incomingMessageCallb
                 {
                   if (key != nKey)
                   {
-                    OcNodeType* node = octomap->search(key);
+                    typename OcTreeType::NodeType* node = octomap->search(key);
 
                     // the left part evaluates to 1 for free voxels and 2 for occupied voxels
                     if (!(node && ((((int)octomap->isNodeOccupied(node)) + 1) & render_mode_mask)))
@@ -521,8 +521,8 @@ void TemplatedOccupancyGridDisplay<OcTreeType, OcNodeType>::incomingMessageCallb
 
 #include <pluginlib/class_list_macros.h>
 
-typedef octomap_rviz_plugin::TemplatedOccupancyGridDisplay<octomap::OcTree, octomap::OcTreeNode> OcTreeGridDisplay;
-typedef octomap_rviz_plugin::TemplatedOccupancyGridDisplay<octomap::OcTreeStamped, octomap::OcTreeNodeStamped> OcTreeStampedGridDisplay;
+typedef octomap_rviz_plugin::TemplatedOccupancyGridDisplay<octomap::OcTree> OcTreeGridDisplay;
+typedef octomap_rviz_plugin::TemplatedOccupancyGridDisplay<octomap::OcTreeStamped> OcTreeStampedGridDisplay;
 
 PLUGINLIB_EXPORT_CLASS( OcTreeGridDisplay, rviz::Display)
 PLUGINLIB_EXPORT_CLASS( OcTreeStampedGridDisplay, rviz::Display)

--- a/src/occupancy_map_display.cpp
+++ b/src/occupancy_map_display.cpp
@@ -132,8 +132,8 @@ void OccupancyMapDisplay::unsubscribe()
 }
 
 
-template <typename OcTreeType, typename OcNodeType>
-void TemplatedOccupancyMapDisplay<OcTreeType, OcNodeType>::handleOctomapBinaryMessage(const octomap_msgs::OctomapConstPtr& msg)
+template <typename OcTreeType>
+void TemplatedOccupancyMapDisplay<OcTreeType>::handleOctomapBinaryMessage(const octomap_msgs::OctomapConstPtr& msg)
 {
 
   ROS_DEBUG("Received OctomapBinary message (size: %d bytes)", (int)msg->data.size());
@@ -219,8 +219,8 @@ void TemplatedOccupancyMapDisplay<OcTreeType, OcNodeType>::handleOctomapBinaryMe
 } // namespace rviz
 
 #include <pluginlib/class_list_macros.h>
-typedef octomap_rviz_plugin::TemplatedOccupancyMapDisplay<octomap::OcTree, octomap::OcTreeNode> OcTreeMapDisplay;
-typedef octomap_rviz_plugin::TemplatedOccupancyMapDisplay<octomap::OcTreeStamped, octomap::OcTreeNodeStamped> OcTreeStampedMapDisplay;
+typedef octomap_rviz_plugin::TemplatedOccupancyMapDisplay<octomap::OcTree> OcTreeMapDisplay;
+typedef octomap_rviz_plugin::TemplatedOccupancyMapDisplay<octomap::OcTreeStamped> OcTreeStampedMapDisplay;
 
 PLUGINLIB_EXPORT_CLASS( OcTreeMapDisplay, rviz::Display)
 PLUGINLIB_EXPORT_CLASS( OcTreeStampedMapDisplay, rviz::Display)

--- a/src/occupancy_map_display.cpp
+++ b/src/occupancy_map_display.cpp
@@ -132,16 +132,17 @@ void OccupancyMapDisplay::unsubscribe()
 }
 
 
-void OccupancyMapDisplay::handleOctomapBinaryMessage(const octomap_msgs::OctomapConstPtr& msg)
+template <typename OcTreeType, typename OcNodeType>
+void TemplatedOccupancyMapDisplay<OcTreeType, OcNodeType>::handleOctomapBinaryMessage(const octomap_msgs::OctomapConstPtr& msg)
 {
 
   ROS_DEBUG("Received OctomapBinary message (size: %d bytes)", (int)msg->data.size());
 
   // creating octree
-  octomap::OcTree* octomap = NULL;
+  OcTreeType* octomap = NULL;
   octomap::AbstractOcTree* tree = octomap_msgs::msgToMap(*msg);
   if (tree){
-    octomap = dynamic_cast<octomap::OcTree*>(tree);
+    octomap = dynamic_cast<OcTreeType*>(tree);
   }
 
   if (!octomap)
@@ -179,7 +180,7 @@ void OccupancyMapDisplay::handleOctomapBinaryMessage(const octomap_msgs::Octomap
 
     // traverse all leafs in the tree:
   unsigned int treeDepth = std::min<unsigned int>(octree_depth_, octomap->getTreeDepth());
-  for (octomap::OcTree::iterator it = octomap->begin(treeDepth), end = octomap->end(); it != end; ++it)
+  for (typename OcTreeType::iterator it = octomap->begin(treeDepth), end = octomap->end(); it != end; ++it)
   {
     bool occupied = octomap->isNodeOccupied(*it);
     int intSize = 1 << (octree_depth_ - it.getDepth());
@@ -218,4 +219,8 @@ void OccupancyMapDisplay::handleOctomapBinaryMessage(const octomap_msgs::Octomap
 } // namespace rviz
 
 #include <pluginlib/class_list_macros.h>
-PLUGINLIB_EXPORT_CLASS( octomap_rviz_plugin::OccupancyMapDisplay, rviz::Display)
+typedef octomap_rviz_plugin::TemplatedOccupancyMapDisplay<octomap::OcTree, octomap::OcTreeNode> OcTreeMapDisplay;
+typedef octomap_rviz_plugin::TemplatedOccupancyMapDisplay<octomap::OcTreeStamped, octomap::OcTreeNodeStamped> OcTreeStampedMapDisplay;
+
+PLUGINLIB_EXPORT_CLASS( OcTreeMapDisplay, rviz::Display)
+PLUGINLIB_EXPORT_CLASS( OcTreeStampedMapDisplay, rviz::Display)


### PR DESCRIPTION
The octomap_rviz_plugins are templated so that new plugins for OcTreeStamped type Octomaps can be visualized. The templates assume that the 
OcTreeType is a dervied from OccupancyOcTreeBase
OcNodeType is a dervied from OcTreeNode